### PR TITLE
Pushing in hotfix for loading ESM modules when the project using the …

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.2",
   "description": "A Rollup plugin to import CSS into JavaScript",
   "main": "dist/plugin.cjs.js",
-  "module": "dist/plugin.esm.js",
+  "module": "dist/plugin.esm.mjs",
   "types": "types/plugin.d.ts",
   "scripts": {
     "build": "rollup -c",
@@ -23,8 +23,8 @@
   "exports": {
     ".": {
       "require": "./dist/plugin.cjs.js",
-      "import": "./dist/plugin.esm.js",
-      "default": "./dist/plugin.esm.js"
+      "import": "./dist/plugin.esm.mjs",
+      "default": "./dist/plugin.esm.mjs"
     }
   },
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ import { builtinModules } from "module";
 export default {
     input: "src/index.js",
     output: [
-        { file: "dist/plugin.esm.js", format: "esm" },
+        { file: "dist/plugin.esm.mjs", format: "esm" },
         { file: "dist/plugin.cjs.js", format: "cjs", exports: "default" },
     ],
     plugins: [


### PR DESCRIPTION
As I mentioned on #5, the extension for the ESM module should be .mjs. This pull request applies that change.