### PR TITLE
Update peer deps to allow for 4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "@rollup/pluginutils": "^5.0.4"
   },
   "peerDependencies": {
-    "rollup": "^2.x.x || ^3.x.x"
+    "rollup": "^2.x.x || ^3.x.x || ^4.x.x"
   }
 }


### PR DESCRIPTION
This seems to work ok. Though I'd imagine you'd want to check rollups api changes publishing.