### PR TITLE
make style injection more robust

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ export default (options = {}) => {
             /* if inject is enabled, we want to simply inject the stylesheet into the document head */
             if (options.inject) {
                 return {
-                    code: `document.head.innerHTML += ${JSON.stringify(`<style>${transformedCode}</style>`)};`,
+                    code: `document.head.appendChild(document.createElement('style')).textContent=${JSON.stringify(transformedCode)};`,
                     map: { mappings: "" }
                 };
             }


### PR DESCRIPTION
The original implementation (`document.head.innerHTML += ...`) is

1. Less performant as it may unnecessarily reconstruct the whole `head` element for multiple times
2. May cause issues like https://github.com/ecomfe/vue-echarts/issues/805
