### PR TITLE
Modified the deprecated assertion syntax to attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ export default (options = {}) => {
 
             /* if modules are enabled or an import uses native css module syntax, export it as a CSSStyleSheet */
             const moduleInfo = this.getModuleInfo(id);
-            if (options.modules || moduleInfo.assertions?.type == "css") {
+            if (options.modules || moduleInfo.attributes?.type == "css") {
                 return {
                     code: `const sheet = new CSSStyleSheet();sheet.replaceSync(${JSON.stringify(transformedCode)});export default sheet;`,
                     map: { mappings: "" }


### PR DESCRIPTION
Rollup no longer supports import assertions, https://rollupjs.org/plugin-development/#this-getmoduleinfo